### PR TITLE
Added test cases for each individual option to NullnessLite

### DIFF
--- a/checker/src/test/java/tests/NullnessLiteOptBoxpTest.java
+++ b/checker/src/test/java/tests/NullnessLiteOptBoxpTest.java
@@ -6,7 +6,7 @@ import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=mapk} command-line
+ * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=boxp} command-line
  * argument.
  */
 public class NullnessLiteOptBoxpTest extends CheckerFrameworkPerDirectoryTest {

--- a/checker/src/test/java/tests/NullnessLiteOptBoxpTest.java
+++ b/checker/src/test/java/tests/NullnessLiteOptBoxpTest.java
@@ -1,0 +1,30 @@
+package tests;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=mapk} command-line
+ * argument.
+ */
+public class NullnessLiteOptBoxpTest extends CheckerFrameworkPerDirectoryTest {
+
+    public NullnessLiteOptBoxpTest(List<File> testFiles) {
+
+        super(
+                testFiles,
+                org.checkerframework.checker.nullness.NullnessChecker.class,
+                "nullness",
+                "-Anomsgtext",
+                "-AstubWarnIfNotFound",
+                "-ANullnessLite=boxp");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+
+        return new String[] {"nullness-liteoption-boxp"};
+    }
+}

--- a/checker/src/test/java/tests/NullnessLiteOptInitTest.java
+++ b/checker/src/test/java/tests/NullnessLiteOptInitTest.java
@@ -6,7 +6,7 @@ import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=mapk} command-line
+ * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=init} command-line
  * argument.
  */
 public class NullnessLiteOptInitTest extends CheckerFrameworkPerDirectoryTest {

--- a/checker/src/test/java/tests/NullnessLiteOptInitTest.java
+++ b/checker/src/test/java/tests/NullnessLiteOptInitTest.java
@@ -1,0 +1,30 @@
+package tests;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=mapk} command-line
+ * argument.
+ */
+public class NullnessLiteOptInitTest extends CheckerFrameworkPerDirectoryTest {
+
+    public NullnessLiteOptInitTest(List<File> testFiles) {
+
+        super(
+                testFiles,
+                org.checkerframework.checker.nullness.NullnessChecker.class,
+                "nullness",
+                "-Anomsgtext",
+                "-AstubWarnIfNotFound",
+                "-ANullnessLite=init");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+
+        return new String[] {"nullness-liteoption-init"};
+    }
+}

--- a/checker/src/test/java/tests/NullnessLiteOptInvaTest.java
+++ b/checker/src/test/java/tests/NullnessLiteOptInvaTest.java
@@ -1,0 +1,30 @@
+package tests;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=mapk} command-line
+ * argument.
+ */
+public class NullnessLiteOptInvaTest extends CheckerFrameworkPerDirectoryTest {
+
+    public NullnessLiteOptInvaTest(List<File> testFiles) {
+
+        super(
+                testFiles,
+                org.checkerframework.checker.nullness.NullnessChecker.class,
+                "nullness",
+                "-Anomsgtext",
+                "-AstubWarnIfNotFound",
+                "-ANullnessLite=inva");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+
+        return new String[] {"nullness-liteoption-inva"};
+    }
+}

--- a/checker/src/test/java/tests/NullnessLiteOptInvaTest.java
+++ b/checker/src/test/java/tests/NullnessLiteOptInvaTest.java
@@ -6,7 +6,7 @@ import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=mapk} command-line
+ * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=inva} command-line
  * argument.
  */
 public class NullnessLiteOptInvaTest extends CheckerFrameworkPerDirectoryTest {

--- a/checker/src/test/java/tests/NullnessLiteOptMapkTest.java
+++ b/checker/src/test/java/tests/NullnessLiteOptMapkTest.java
@@ -1,0 +1,30 @@
+package tests;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * JUnit tests for the Nullness Checker -- testing {@code -ANullnessLite=mapk} command-line
+ * argument.
+ */
+public class NullnessLiteOptMapkTest extends CheckerFrameworkPerDirectoryTest {
+
+    public NullnessLiteOptMapkTest(List<File> testFiles) {
+
+        super(
+                testFiles,
+                org.checkerframework.checker.nullness.NullnessChecker.class,
+                "nullness",
+                "-Anomsgtext",
+                "-AstubWarnIfNotFound",
+                "-ANullnessLite=mapk");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+
+        return new String[] {"nullness-liteoption-mapk"};
+    }
+}

--- a/checker/tests/nullness-liteoption-boxp/NullnessLiteBoxing1.java
+++ b/checker/tests/nullness-liteoption-boxp/NullnessLiteBoxing1.java
@@ -1,0 +1,110 @@
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.qual.Pure;
+
+/**
+ * This class illustrates a correct implementation of the following assumption: Assume that boxing
+ * of primitives is @Pure: it returns the same value on every call.
+ *
+ * <p>8 Boxed classes: Integer, Float, Long, Short, Character, Double, Boolean, Byte (Boolean and
+ * Byte has valueOf as @Pure by default)
+ */
+public class NullnessLiteBoxing1 {
+
+    public static void main(String[] args) {}
+
+    // Map key analysis could work with boxing assumptions
+    public void testMapKeyChecker(double key, Map<Double, Object> m) {
+        if (m.get(Double.valueOf(key)) != null) {
+            m.get(Double.valueOf(key)).toString(); // NullnessLite ON = no error
+        }
+    }
+
+    void testIntegerWithPure(int x) {
+        if (obj(Integer.valueOf(x)) != null) {
+            obj(Integer.valueOf(x)).toString(); // warning not @Pure
+        }
+    }
+
+    void testFloatWithPure(float f) {
+        if (obj(Float.valueOf(f)) != null) {
+            obj(Float.valueOf(f)).toString(); // warning not @Pure
+        }
+    }
+
+    void testLongWithPure(long l) {
+        if (obj(Long.valueOf(l)) != null) {
+            obj(Long.valueOf(l)).toString(); // warning not @Pure
+        }
+    }
+
+    void testShortWithPure(short s) {
+        if (obj(Short.valueOf(s)) != null) {
+            obj(Short.valueOf(s)).toString(); // warning not @Pure
+        }
+    }
+
+    void testByteWithPure(byte b) {
+        if (obj(Byte.valueOf(b)) != null) {
+            obj(Byte.valueOf(b)).toString(); // no warning
+        }
+    }
+
+    void testCharacterWithPure(char c) {
+        if (obj(Character.valueOf(c)) != null) {
+            obj(Character.valueOf(c)).toString(); // warning not @Pure
+        }
+    }
+
+    void testDoubleWithPure(double d) {
+        if (obj(Double.valueOf(d)) != null) {
+            obj(Double.valueOf(d)).toString(); // warning not @Pure
+        }
+    }
+
+    void testBooleanWithPure(boolean b) {
+        if (obj(Boolean.valueOf(b)) != null) {
+            obj(Boolean.valueOf(b)).toString(); // no warning
+        }
+    }
+
+    @Pure
+    @Nullable Object obj(int i) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(float f) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(long l) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(short s) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(byte b) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(char c) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(double d) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(boolean b) {
+        return null;
+    }
+}

--- a/checker/tests/nullness-liteoption-boxp/NullnessLiteInit1.java
+++ b/checker/tests/nullness-liteoption-boxp/NullnessLiteInit1.java
@@ -1,0 +1,35 @@
+// This class illustrates a correct implementation of "-ANullnessLite=boxp":
+// check when "-ANullnessLite=boxp", the Nullness_Lite does not disable
+// the uninitialized errors from the Initialization Checker;
+//
+// Uninitialized errors are from static fields uninitialized
+// at declaration and non-static fields uninitialized in the
+// constructor. The Nullness_Lite disallows these errors.
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// :: error: (initialization.fields.uninitialized)
+public class NullnessLiteInit1 {
+    static Object o1; // uninit error issued by the Nullness Checker
+    static @Nullable Object o2;
+
+    Object o3;
+    @Nullable Object o4;
+
+    // :: error: (initialization.fields.uninitialized)
+    public NullnessLiteInit1(int x, int y) {
+        // uninit error issued by the Nullness Checker
+        // :: error: (method.invocation.invalid)
+        m();
+    }
+
+    public void m() {
+        // although o3 is initialized here,
+        // the Nullness Checker assumes the constructor
+        // should initilaized all fields. What's more,
+        // the Nullness Checker issue a unrelated error
+        // to warn users for the side effects of calling
+        // a helper method in the constructor.
+        // The Nullness_Lite can do nothing about it.
+        o3 = new Object();
+    }
+}

--- a/checker/tests/nullness-liteoption-boxp/NullnessLiteInvalidDataflow1.java
+++ b/checker/tests/nullness-liteoption-boxp/NullnessLiteInvalidDataflow1.java
@@ -1,0 +1,78 @@
+// This class illustrates a correct implementation of "-ANullnessLite=boxp":
+// check when "-ANullnessLite=boxp", the Nullness_Lite does not disable
+// the invalidation of dataflow;
+//
+// The Invalidation of dataflow include two aspects:
+// 1). Methods call cannot invalidate the dataflow facts.
+//     In other words, assume all methods call are SideEffectFree.
+// 2). Variables assignement cannot invalidate the dataflow facts
+//     of other variables.
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class NullnessLiteInvalidDataflow1 {
+    public static @Nullable Node myField;
+
+    // test methods call
+    public static void m1() {
+        myField = new Node("123");
+
+        if (myField != null) {
+            dummyMethod();
+            // error issued by the Nullness Checker
+            // :: error: (dereference.of.nullable)
+            myField.toString(); // "-ANullnessLite=boxp" = error
+        }
+    }
+
+    public static void dummyMethod() {}
+
+    // test aliasing in field
+    public static void m2() {
+        myField = new Node("");
+        Node a = new Node("");
+        a.next = new Node("");
+
+        if (a.next != null) {
+            myField.next = null;
+            // error issued by the Nullness Checker
+            // :: error: (dereference.of.nullable)
+            a.next.toString(); // "-ANullnessLite=boxp" = error
+        }
+    }
+
+    // test aliasing in array
+    public void arrayAccess() {
+        Node a = new Node("");
+        Node b = new Node("");
+        Node[] c = new Node[2];
+        a.next = b;
+        c[0] = a;
+        c[1] = a.next;
+
+        if (b.str != null) {
+            c[1].str = null;
+            // error issued by the Nullness Checker
+            // :: error: (dereference.of.nullable)
+            b.str.toString(); //  "-ANullnessLite=boxp" = error
+        }
+    }
+
+    public static class Node {
+        public @Nullable String str;
+        public @Nullable Node next;
+
+        public Node(String str) {
+            this.str = str;
+            this.next = null;
+        }
+
+        @Override
+        public String toString() {
+            if (str != null) {
+                return str;
+            } else {
+                return "null";
+            }
+        }
+    }
+}

--- a/checker/tests/nullness-liteoption-boxp/NullnessLiteMapKey1.java
+++ b/checker/tests/nullness-liteoption-boxp/NullnessLiteMapKey1.java
@@ -1,0 +1,88 @@
+import java.util.HashMap;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.KeyFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * This class illustrates the correct implementation of "-ANullnessLite=boxp": the following feature
+ * will be disabled, and tests worked just like the Nullness Checker.
+ *
+ * <p>This class illustrates use of keyfor type annotations. Since the Nullness Checker has no
+ * dataflow analysis for Map.put() method else where, 1) it does not warn for all Map.get(key)
+ * method if keys are labeled with @KeyFor(); 2) it warns for Map.get(key) where elements are put in
+ * the map elsewhere, say not within the same function.
+ *
+ * <p>NullnessLite: No map key analysis; assume that, at every call to Map.get, the given key
+ * appears in the map. tests: 1) keyfor error still exists 2) the result of map.get() is always
+ * non-null.
+ */
+public class NullnessLiteMapKey1 {
+
+    // 1) keyfor error still exists
+    void test1() {
+        Map<@Nullable String, @Nullable String> m =
+                new HashMap<@Nullable String, @Nullable String>();
+        Map<String, @Nullable String> n = new HashMap<String, @Nullable String>();
+
+        @KeyFor("m") String km = new @KeyFor("m") String("km");
+        @KeyFor("n") String kn = new @KeyFor("n") String("kn");
+        @KeyFor({"m", "n"}) String kmn = new @KeyFor({"m", "n"}) String("kmn");
+
+        km = kmn;
+        // :: error: (assignment.type.incompatible)
+        km = kn;
+    }
+
+    // 2) the result of map.get() is always non-null.
+    void test2() {
+        Map<@Nullable String, @Nullable String> m =
+                new HashMap<@Nullable String, @Nullable String>();
+        Map<String, @Nullable String> n = new HashMap<String, @Nullable String>();
+
+        @KeyFor("m") String in = new @KeyFor("m") String("in");
+        String notin = "notin";
+        //        m.put(in, in);
+        //        n.put(in, in);
+
+        m.get(in).toString(); // OK - a key for map m
+        // :: error: (dereference.of.nullable)
+        m.get(notin).toString(); // NullnessLite ON = no error
+    }
+
+    void showFalseWarningsAndErrors() {
+        Map<String, String> m = new HashMap<String, String>();
+
+        @KeyFor("m") String notin = new @KeyFor("m") String("in");
+        String in = "in";
+
+        foo(m, in);
+
+        m.get(notin).toString(); // error but no warning
+        // :: error: (dereference.of.nullable)
+        m.get(in).toString(); // Ok but a warning
+    }
+
+    void showFalseWarnings() {
+        Map<String, String> m = new HashMap<String, String>();
+        String in = "in";
+        foo(m, in);
+
+        // :: error: (dereference.of.nullable)
+        m.get(in).toString(); // Ok but a warning
+    }
+
+    void foo(Map<String, String> m, String in) {
+        m.put(in, in);
+        return;
+    }
+
+    void wierdKeyFor() {
+        Map<String, String> m = new HashMap<String, String>();
+
+        String in = "in";
+        foo(m, in);
+
+        // :: error: (dereference.of.nullable)
+        m.get(in).toString(); // Ok but a warning
+    }
+}

--- a/checker/tests/nullness-liteoption-boxp/README
+++ b/checker/tests/nullness-liteoption-boxp/README
@@ -1,0 +1,9 @@
+s directory contains tests for the Nullness Checker, with the
+-ANullnessLite=mapk flag.
+
+To add a new file to the test suite, just add it to this directory.
+For more details, see
+  ../README
+
+To run the tests, do this:
+  (cd $CHECKERFRAMEWORK && ./gradlew NullnessLiteOptBoxpTest)

--- a/checker/tests/nullness-liteoption-init/NullnessLiteBoxing1.java
+++ b/checker/tests/nullness-liteoption-init/NullnessLiteBoxing1.java
@@ -1,0 +1,124 @@
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.qual.Pure;
+
+/**
+ * This class illustrates a correct implementation of "-ANullnessLite=inva": the following
+ * assumption is not enabled: Assume that boxing of primitives is @Pure: it returns the same value
+ * on every call.
+ *
+ * <p>8 Boxed classes: Integer, Float, Long, Short, Character, Double, Boolean, Byte (Boolean and
+ * Byte has valueOf as @Pure by default)
+ */
+public class NullnessLiteBoxing1 {
+
+    public static void main(String[] args) {}
+
+    // Map key analysis could work with boxing assumptions
+    public void testinvaeyChecker(double key, Map<Double, Object> m) {
+        if (m.get(Double.valueOf(key)) != null) {
+            // :: error: (dereference.of.nullable)
+            m.get(Double.valueOf(key)).toString(); // "ANullnessLite=init" ON = error
+        }
+    }
+
+    void testIntegerWithPure(int x) {
+        if (obj(Integer.valueOf(x)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Integer.valueOf(x)).toString(); // "ANullnessLite=init" = error not @Pure
+        }
+    }
+
+    void testFloatWithPure(float f) {
+        if (obj(Float.valueOf(f)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Float.valueOf(f)).toString(); // "ANullnessLite=init" = error not @Pure
+        }
+    }
+
+    void testLongWithPure(long l) {
+        if (obj(Long.valueOf(l)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Long.valueOf(l)).toString(); // "ANullnessLite=init" = error not @Pure
+        }
+    }
+
+    void testShortWithPure(short s) {
+        if (obj(Short.valueOf(s)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Short.valueOf(s)).toString(); // "ANullnessLite=init" = error not @Pure
+        }
+    }
+
+    void testByteWithPure(byte b) {
+        if (obj(Byte.valueOf(b)) != null) {
+            obj(Byte.valueOf(b)).toString(); // no warning
+        }
+    }
+
+    void testCharacterWithPure(char c) {
+        if (obj(Character.valueOf(c)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Character.valueOf(c)).toString(); // "ANullnessLite=init" = error not @Pure
+        }
+    }
+
+    void testDoubleWithPure(double d) {
+        if (obj(Double.valueOf(d)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Double.valueOf(d)).toString(); // "ANullnessLite=init" = error not @Pure
+        }
+    }
+
+    void testBooleanWithPure(boolean b) {
+        if (obj(Boolean.valueOf(b)) != null) {
+            obj(Boolean.valueOf(b)).toString(); // no warning
+        }
+    }
+
+    @Pure
+    @Nullable Object obj(int i) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(float f) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(long l) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(short s) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(byte b) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(char c) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(double d) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(boolean b) {
+        return null;
+    }
+}

--- a/checker/tests/nullness-liteoption-init/NullnessLiteInit1.java
+++ b/checker/tests/nullness-liteoption-init/NullnessLiteInit1.java
@@ -1,0 +1,32 @@
+// This test aims to check whether the Nullness_Lite disables
+// the uninitialized errors from the Initialization Checker;
+//
+// Uninitialized errors are from static fields uninitialized
+// at declaration and non-static fields uninitialized in the
+// constructor. The Nullness_Lite disallows these errors.
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class NullnessLiteInit1 {
+    static Object o1; // uninit error issued by the Nullness Checker
+    static @Nullable Object o2;
+
+    Object o3;
+    @Nullable Object o4;
+
+    public NullnessLiteInit1(int x, int y) {
+        // uninit error issued by the Nullness Checker
+        // :: error: (method.invocation.invalid)
+        m();
+    }
+
+    public void m() {
+        // although o3 is initialized here,
+        // the Nullness Checker assumes the constructor
+        // should initilaized all fields. What's more,
+        // the Nullness Checker issue a unrelated error
+        // to warn users for the side effects of calling
+        // a helper method in the constructor.
+        // The Nullness_Lite can do nothing about it.
+        o3 = new Object();
+    }
+}

--- a/checker/tests/nullness-liteoption-init/NullnessLiteInvalidDataflow1.java
+++ b/checker/tests/nullness-liteoption-init/NullnessLiteInvalidDataflow1.java
@@ -1,0 +1,78 @@
+// This class illustrates a correct implementation of "-ANullnessLite=init":
+// check when "-ANullnessLite=init", the Nullness_Lite does not disable
+// the invalidation of dataflow;
+//
+// The Invalidation of dataflow include two aspects:
+// 1). Methods call cannot invalidate the dataflow facts.
+//     In other words, assume all methods call are SideEffectFree.
+// 2). Variables assignement cannot invalidate the dataflow facts
+//     of other variables.
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class NullnessLiteInvalidDataflow1 {
+    public static @Nullable Node myField;
+
+    // test methods call
+    public static void m1() {
+        myField = new Node("123");
+
+        if (myField != null) {
+            dummyMethod();
+            // error issued by the Nullness Checker
+            // :: error: (dereference.of.nullable)
+            myField.toString(); // "-ANullnessLite=init" = error
+        }
+    }
+
+    public static void dummyMethod() {}
+
+    // test aliasing in field
+    public static void m2() {
+        myField = new Node("");
+        Node a = new Node("");
+        a.next = new Node("");
+
+        if (a.next != null) {
+            myField.next = null;
+            // error issued by the Nullness Checker
+            // :: error: (dereference.of.nullable)
+            a.next.toString(); // "-ANullnessLite=init" = error
+        }
+    }
+
+    // test aliasing in array
+    public void arrayAccess() {
+        Node a = new Node("");
+        Node b = new Node("");
+        Node[] c = new Node[2];
+        a.next = b;
+        c[0] = a;
+        c[1] = a.next;
+
+        if (b.str != null) {
+            c[1].str = null;
+            // error issued by the Nullness Checker
+            // :: error: (dereference.of.nullable)
+            b.str.toString(); //  "-ANullnessLite=init" = error
+        }
+    }
+
+    public static class Node {
+        public @Nullable String str;
+        public @Nullable Node next;
+
+        public Node(String str) {
+            this.str = str;
+            this.next = null;
+        }
+
+        @Override
+        public String toString() {
+            if (str != null) {
+                return str;
+            } else {
+                return "null";
+            }
+        }
+    }
+}

--- a/checker/tests/nullness-liteoption-init/NullnessLiteMapKey1.java
+++ b/checker/tests/nullness-liteoption-init/NullnessLiteMapKey1.java
@@ -1,0 +1,88 @@
+import java.util.HashMap;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.KeyFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * This class illustrates the correct implementation of "-ANullnessLite=init": the following feature
+ * will be disabled, and tests worked just like the Nullness Checker.
+ *
+ * <p>This class illustrates use of keyfor type annotations. Since the Nullness Checker has no
+ * dataflow analysis for Map.put() method else where, 1) it does not warn for all Map.get(key)
+ * method if keys are labeled with @KeyFor(); 2) it warns for Map.get(key) where elements are put in
+ * the map elsewhere, say not within the same function.
+ *
+ * <p>NullnessLite: No map key analysis; assume that, at every call to Map.get, the given key
+ * appears in the map. tests: 1) keyfor error still exists 2) the result of map.get() is always
+ * non-null.
+ */
+public class NullnessLiteMapKey1 {
+
+    // 1) keyfor error still exists
+    void test1() {
+        Map<@Nullable String, @Nullable String> m =
+                new HashMap<@Nullable String, @Nullable String>();
+        Map<String, @Nullable String> n = new HashMap<String, @Nullable String>();
+
+        @KeyFor("m") String km = new @KeyFor("m") String("km");
+        @KeyFor("n") String kn = new @KeyFor("n") String("kn");
+        @KeyFor({"m", "n"}) String kmn = new @KeyFor({"m", "n"}) String("kmn");
+
+        km = kmn;
+        // :: error: (assignment.type.incompatible)
+        km = kn;
+    }
+
+    // 2) the result of map.get() is always non-null.
+    void test2() {
+        Map<@Nullable String, @Nullable String> m =
+                new HashMap<@Nullable String, @Nullable String>();
+        Map<String, @Nullable String> n = new HashMap<String, @Nullable String>();
+
+        @KeyFor("m") String in = new @KeyFor("m") String("in");
+        String notin = "notin";
+        //        m.put(in, in);
+        //        n.put(in, in);
+
+        m.get(in).toString(); // OK - a key for map m
+        // :: error: (dereference.of.nullable)
+        m.get(notin).toString(); // NullnessLite ON = no error
+    }
+
+    void showFalseWarningsAndErrors() {
+        Map<String, String> m = new HashMap<String, String>();
+
+        @KeyFor("m") String notin = new @KeyFor("m") String("in");
+        String in = "in";
+
+        foo(m, in);
+
+        m.get(notin).toString(); // error but no warning
+        // :: error: (dereference.of.nullable)
+        m.get(in).toString(); // Ok but a warning
+    }
+
+    void showFalseWarnings() {
+        Map<String, String> m = new HashMap<String, String>();
+        String in = "in";
+        foo(m, in);
+
+        // :: error: (dereference.of.nullable)
+        m.get(in).toString(); // Ok but a warning
+    }
+
+    void foo(Map<String, String> m, String in) {
+        m.put(in, in);
+        return;
+    }
+
+    void wierdKeyFor() {
+        Map<String, String> m = new HashMap<String, String>();
+
+        String in = "in";
+        foo(m, in);
+
+        // :: error: (dereference.of.nullable)
+        m.get(in).toString(); // Ok but a warning
+    }
+}

--- a/checker/tests/nullness-liteoption-init/README
+++ b/checker/tests/nullness-liteoption-init/README
@@ -1,0 +1,9 @@
+s directory contains tests for the Nullness Checker, with the
+-ANullnessLite=mapk flag.
+
+To add a new file to the test suite, just add it to this directory.
+For more details, see
+  ../README
+
+To run the tests, do this:
+  (cd $CHECKERFRAMEWORK && ./gradlew NullnessLiteOptInitTest)

--- a/checker/tests/nullness-liteoption-inva/NullnessLiteBoxing1.java
+++ b/checker/tests/nullness-liteoption-inva/NullnessLiteBoxing1.java
@@ -1,0 +1,124 @@
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.qual.Pure;
+
+/**
+ * This class illustrates a correct implementation of "-ANullnessLite=inva": the following
+ * assumption is not enabled: Assume that boxing of primitives is @Pure: it returns the same value
+ * on every call.
+ *
+ * <p>8 Boxed classes: Integer, Float, Long, Short, Character, Double, Boolean, Byte (Boolean and
+ * Byte has valueOf as @Pure by default)
+ */
+public class NullnessLiteBoxing1 {
+
+    public static void main(String[] args) {}
+
+    // Map key analysis could work with boxing assumptions
+    public void testMapkeyChecker(double key, Map<Double, Object> m) {
+        if (m.get(Double.valueOf(key)) != null) {
+            // :: error: (dereference.of.nullable)
+            m.get(Double.valueOf(key)).toString(); // "ANullnessLite=inva" ON = error
+        }
+    }
+
+    void testIntegerWithPure(int x) {
+        if (obj(Integer.valueOf(x)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Integer.valueOf(x)).toString(); // "ANullnessLite=inva" = error not @Pure
+        }
+    }
+
+    void testFloatWithPure(float f) {
+        if (obj(Float.valueOf(f)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Float.valueOf(f)).toString(); // "ANullnessLite=inva" = error not @Pure
+        }
+    }
+
+    void testLongWithPure(long l) {
+        if (obj(Long.valueOf(l)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Long.valueOf(l)).toString(); // "ANullnessLite=inva" = error not @Pure
+        }
+    }
+
+    void testShortWithPure(short s) {
+        if (obj(Short.valueOf(s)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Short.valueOf(s)).toString(); // "ANullnessLite=inva" = error not @Pure
+        }
+    }
+
+    void testByteWithPure(byte b) {
+        if (obj(Byte.valueOf(b)) != null) {
+            obj(Byte.valueOf(b)).toString(); // no warning
+        }
+    }
+
+    void testCharacterWithPure(char c) {
+        if (obj(Character.valueOf(c)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Character.valueOf(c)).toString(); // "ANullnessLite=inva" = error not @Pure
+        }
+    }
+
+    void testDoubleWithPure(double d) {
+        if (obj(Double.valueOf(d)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Double.valueOf(d)).toString(); // "ANullnessLite=inva" = error not @Pure
+        }
+    }
+
+    void testBooleanWithPure(boolean b) {
+        if (obj(Boolean.valueOf(b)) != null) {
+            obj(Boolean.valueOf(b)).toString(); // no warning
+        }
+    }
+
+    @Pure
+    @Nullable Object obj(int i) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(float f) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(long l) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(short s) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(byte b) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(char c) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(double d) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(boolean b) {
+        return null;
+    }
+}

--- a/checker/tests/nullness-liteoption-inva/NullnessLiteInit1.java
+++ b/checker/tests/nullness-liteoption-inva/NullnessLiteInit1.java
@@ -1,0 +1,35 @@
+// This class illustrates a correct implementation of "-ANullnessLite=boxp":
+// check when "-ANullnessLite=boxp", the Nullness_Lite does not disable
+// the uninitialized errors from the Initialization Checker;
+//
+// Uninitialized errors are from static fields uninitialized
+// at declaration and non-static fields uninitialized in the
+// constructor. The Nullness_Lite disallows these errors.
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// :: error: (initialization.fields.uninitialized)
+public class NullnessLiteInit1 {
+    static Object o1; // uninit error issued by the Nullness Checker
+    static @Nullable Object o2;
+
+    Object o3;
+    @Nullable Object o4;
+
+    // :: error: (initialization.fields.uninitialized)
+    public NullnessLiteInit1(int x, int y) {
+        // uninit error issued by the Nullness Checker
+        // :: error: (method.invocation.invalid)
+        m();
+    }
+
+    public void m() {
+        // although o3 is initialized here,
+        // the Nullness Checker assumes the constructor
+        // should initilaized all fields. What's more,
+        // the Nullness Checker issue a unrelated error
+        // to warn users for the side effects of calling
+        // a helper method in the constructor.
+        // The Nullness_Lite can do nothing about it.
+        o3 = new Object();
+    }
+}

--- a/checker/tests/nullness-liteoption-inva/NullnessLiteInvalidDataflow1.java
+++ b/checker/tests/nullness-liteoption-inva/NullnessLiteInvalidDataflow1.java
@@ -1,0 +1,71 @@
+// This test aims to check whether the Nullness_Lite disables
+// the invalidation of dataflow;
+//
+// The Invalidation of dataflow include two aspects:
+// 1). Methods call cannot invalidate the dataflow facts.
+//     In other words, assume all methods call are SideEffectFree.
+// 2). Variables assignement cannot invalidate the dataflow facts
+//     of other variables.
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class NullnessLiteInvalidDataflow1 {
+    public static @Nullable Node myField;
+
+    // test methods call
+    public static void m1() {
+        myField = new Node("123");
+
+        if (myField != null) {
+            dummyMethod();
+            myField.toString(); // error issued by the Nullness Checker
+        }
+    }
+
+    public static void dummyMethod() {}
+
+    // test aliasing in field
+    public static void m2() {
+        myField = new Node("");
+        Node a = new Node("");
+        a.next = new Node("");
+
+        if (a.next != null) {
+            myField.next = null;
+            a.next.toString(); // error issued by the Nullness Checker
+        }
+    }
+
+    // test aliasing in array
+    public void arrayAccess() {
+        Node a = new Node("");
+        Node b = new Node("");
+        Node[] c = new Node[2];
+        a.next = b;
+        c[0] = a;
+        c[1] = a.next;
+
+        if (b.str != null) {
+            c[1].str = null;
+            b.str.toString(); // Nullness Checker Err here
+        }
+    }
+
+    public static class Node {
+        public @Nullable String str;
+        public @Nullable Node next;
+
+        public Node(String str) {
+            this.str = str;
+            this.next = null;
+        }
+
+        @Override
+        public String toString() {
+            if (str != null) {
+                return str;
+            } else {
+                return "null";
+            }
+        }
+    }
+}

--- a/checker/tests/nullness-liteoption-inva/NullnessLiteMapKey1.java
+++ b/checker/tests/nullness-liteoption-inva/NullnessLiteMapKey1.java
@@ -1,0 +1,88 @@
+import java.util.HashMap;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.KeyFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * This class illustrates the correct implementation of "-ANullnessLite=inva": the following feature
+ * will be disabled, and tests worked just like the Nullness Checker.
+ *
+ * <p>This class illustrates use of keyfor type annotations. Since the Nullness Checker has no
+ * dataflow analysis for Map.put() method else where, 1) it does not warn for all Map.get(key)
+ * method if keys are labeled with @KeyFor(); 2) it warns for Map.get(key) where elements are put in
+ * the map elsewhere, say not within the same function.
+ *
+ * <p>NullnessLite: No map key analysis; assume that, at every call to Map.get, the given key
+ * appears in the map. tests: 1) keyfor error still exists 2) the result of map.get() is always
+ * non-null.
+ */
+public class NullnessLiteMapKey1 {
+
+    // 1) keyfor error still exists
+    void test1() {
+        Map<@Nullable String, @Nullable String> m =
+                new HashMap<@Nullable String, @Nullable String>();
+        Map<String, @Nullable String> n = new HashMap<String, @Nullable String>();
+
+        @KeyFor("m") String km = new @KeyFor("m") String("km");
+        @KeyFor("n") String kn = new @KeyFor("n") String("kn");
+        @KeyFor({"m", "n"}) String kmn = new @KeyFor({"m", "n"}) String("kmn");
+
+        km = kmn;
+        // :: error: (assignment.type.incompatible)
+        km = kn;
+    }
+
+    // 2) the result of map.get() is always non-null.
+    void test2() {
+        Map<@Nullable String, @Nullable String> m =
+                new HashMap<@Nullable String, @Nullable String>();
+        Map<String, @Nullable String> n = new HashMap<String, @Nullable String>();
+
+        @KeyFor("m") String in = new @KeyFor("m") String("in");
+        String notin = "notin";
+        //        m.put(in, in);
+        //        n.put(in, in);
+
+        m.get(in).toString(); // OK - a key for map m
+        // :: error: (dereference.of.nullable)
+        m.get(notin).toString(); // NullnessLite ON = no error
+    }
+
+    void showFalseWarningsAndErrors() {
+        Map<String, String> m = new HashMap<String, String>();
+
+        @KeyFor("m") String notin = new @KeyFor("m") String("in");
+        String in = "in";
+
+        foo(m, in);
+
+        m.get(notin).toString(); // error but no warning
+        // :: error: (dereference.of.nullable)
+        m.get(in).toString(); // Ok but a warning
+    }
+
+    void showFalseWarnings() {
+        Map<String, String> m = new HashMap<String, String>();
+        String in = "in";
+        foo(m, in);
+
+        // :: error: (dereference.of.nullable)
+        m.get(in).toString(); // Ok but a warning
+    }
+
+    void foo(Map<String, String> m, String in) {
+        m.put(in, in);
+        return;
+    }
+
+    void wierdKeyFor() {
+        Map<String, String> m = new HashMap<String, String>();
+
+        String in = "in";
+        foo(m, in);
+
+        // :: error: (dereference.of.nullable)
+        m.get(in).toString(); // Ok but a warning
+    }
+}

--- a/checker/tests/nullness-liteoption-inva/README
+++ b/checker/tests/nullness-liteoption-inva/README
@@ -1,0 +1,9 @@
+s directory contains tests for the Nullness Checker, with the
+-ANullnessLite=mapk flag.
+
+To add a new file to the test suite, just add it to this directory.
+For more details, see
+  ../README
+
+To run the tests, do this:
+  (cd $CHECKERFRAMEWORK && ./gradlew NullnessLiteOptInvaTest)

--- a/checker/tests/nullness-liteoption-mapk/NullnessLiteBoxing1.java
+++ b/checker/tests/nullness-liteoption-mapk/NullnessLiteBoxing1.java
@@ -1,0 +1,123 @@
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.qual.Pure;
+
+/**
+ * This class illustrates a correct implementation of "-ANullnessLite=mapk": the following
+ * assumption is not enabled: Assume that boxing of primitives is @Pure: it returns the same value
+ * on every call.
+ *
+ * <p>8 Boxed classes: Integer, Float, Long, Short, Character, Double, Boolean, Byte (Boolean and
+ * Byte has valueOf as @Pure by default)
+ */
+public class NullnessLiteBoxing1 {
+
+    public static void main(String[] args) {}
+
+    // Map key analysis could work with boxing assumptions
+    public void testMapKeyChecker(double key, Map<Double, Object> m) {
+        if (m.get(Double.valueOf(key)) != null) {
+            m.get(Double.valueOf(key)).toString(); // "ANullnessLite=mapk" ON = no error
+        }
+    }
+
+    void testIntegerWithPure(int x) {
+        if (obj(Integer.valueOf(x)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Integer.valueOf(x)).toString(); // "ANullnessLite=mapk" = error not @Pure
+        }
+    }
+
+    void testFloatWithPure(float f) {
+        if (obj(Float.valueOf(f)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Float.valueOf(f)).toString(); // "ANullnessLite=mapk" = error not @Pure
+        }
+    }
+
+    void testLongWithPure(long l) {
+        if (obj(Long.valueOf(l)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Long.valueOf(l)).toString(); // "ANullnessLite=mapk" = error not @Pure
+        }
+    }
+
+    void testShortWithPure(short s) {
+        if (obj(Short.valueOf(s)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Short.valueOf(s)).toString(); // "ANullnessLite=mapk" = error not @Pure
+        }
+    }
+
+    void testByteWithPure(byte b) {
+        if (obj(Byte.valueOf(b)) != null) {
+            obj(Byte.valueOf(b)).toString(); // no warning
+        }
+    }
+
+    void testCharacterWithPure(char c) {
+        if (obj(Character.valueOf(c)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Character.valueOf(c)).toString(); // "ANullnessLite=mapk" = error not @Pure
+        }
+    }
+
+    void testDoubleWithPure(double d) {
+        if (obj(Double.valueOf(d)) != null) {
+            // NullnessLite ON = no error
+            // :: error: (dereference.of.nullable)
+            obj(Double.valueOf(d)).toString(); // "ANullnessLite=mapk" = error not @Pure
+        }
+    }
+
+    void testBooleanWithPure(boolean b) {
+        if (obj(Boolean.valueOf(b)) != null) {
+            obj(Boolean.valueOf(b)).toString(); // no warning
+        }
+    }
+
+    @Pure
+    @Nullable Object obj(int i) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(float f) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(long l) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(short s) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(byte b) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(char c) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(double d) {
+        return null;
+    }
+
+    @Pure
+    @Nullable Object obj(boolean b) {
+        return null;
+    }
+}

--- a/checker/tests/nullness-liteoption-mapk/NullnessLiteInit1.java
+++ b/checker/tests/nullness-liteoption-mapk/NullnessLiteInit1.java
@@ -1,0 +1,35 @@
+// This class illustrates a correct implementation of "-ANullnessLite=mapk":
+// check when "-ANullnessLite=mapk", the Nullness_Lite does not disable
+// the uninitialized errors from the Initialization Checker;
+//
+// Uninitialized errors are from static fields uninitialized
+// at declaration and non-static fields uninitialized in the
+// constructor. The Nullness_Lite disallows these errors.
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// :: error: (initialization.fields.uninitialized)
+public class NullnessLiteInit1 {
+    static Object o1; // uninit error issued by the Nullness Checker
+    static @Nullable Object o2;
+
+    Object o3;
+    @Nullable Object o4;
+
+    // :: error: (initialization.fields.uninitialized)
+    public NullnessLiteInit1(int x, int y) {
+        // uninit error issued by the Nullness Checker
+        // :: error: (method.invocation.invalid)
+        m();
+    }
+
+    public void m() {
+        // although o3 is initialized here,
+        // the Nullness Checker assumes the constructor
+        // should initilaized all fields. What's more,
+        // the Nullness Checker issue a unrelated error
+        // to warn users for the side effects of calling
+        // a helper method in the constructor.
+        // The Nullness_Lite can do nothing about it.
+        o3 = new Object();
+    }
+}

--- a/checker/tests/nullness-liteoption-mapk/NullnessLiteInvalidDataflow1.java
+++ b/checker/tests/nullness-liteoption-mapk/NullnessLiteInvalidDataflow1.java
@@ -1,0 +1,78 @@
+// This class illustrates a correct implementation of "-ANullnessLite=mapk":
+// check when "-ANullnessLite=mapk", the Nullness_Lite does not disable
+// the invalidation of dataflow;
+//
+// The Invalidation of dataflow include two aspects:
+// 1). Methods call cannot invalidate the dataflow facts.
+//     In other words, assume all methods call are SideEffectFree.
+// 2). Variables assignement cannot invalidate the dataflow facts
+//     of other variables.
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class NullnessLiteInvalidDataflow1 {
+    public static @Nullable Node myField;
+
+    // test methods call
+    public static void m1() {
+        myField = new Node("123");
+
+        if (myField != null) {
+            dummyMethod();
+            // error issued by the Nullness Checker
+            // :: error: (dereference.of.nullable)
+            myField.toString(); // "-ANullnessLite=mapk" = error
+        }
+    }
+
+    public static void dummyMethod() {}
+
+    // test aliasing in field
+    public static void m2() {
+        myField = new Node("");
+        Node a = new Node("");
+        a.next = new Node("");
+
+        if (a.next != null) {
+            myField.next = null;
+            // error issued by the Nullness Checker
+            // :: error: (dereference.of.nullable)
+            a.next.toString(); // "-ANullnessLite=mapk" = error
+        }
+    }
+
+    // test aliasing in array
+    public void arrayAccess() {
+        Node a = new Node("");
+        Node b = new Node("");
+        Node[] c = new Node[2];
+        a.next = b;
+        c[0] = a;
+        c[1] = a.next;
+
+        if (b.str != null) {
+            c[1].str = null;
+            // error issued by the Nullness Checker
+            // :: error: (dereference.of.nullable)
+            b.str.toString(); //  "-ANullnessLite=mapk" = error
+        }
+    }
+
+    public static class Node {
+        public @Nullable String str;
+        public @Nullable Node next;
+
+        public Node(String str) {
+            this.str = str;
+            this.next = null;
+        }
+
+        @Override
+        public String toString() {
+            if (str != null) {
+                return str;
+            } else {
+                return "null";
+            }
+        }
+    }
+}

--- a/checker/tests/nullness-liteoption-mapk/NullnessLiteMapKey1.java
+++ b/checker/tests/nullness-liteoption-mapk/NullnessLiteMapKey1.java
@@ -1,0 +1,81 @@
+import java.util.HashMap;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.KeyFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * This class illustrates use of keyfor type annotations. Since the Nullness Checker has no dataflow
+ * analysis for Map.put() method else where, 1) it does not warn for all Map.get(key) method if keys
+ * are labeled with @KeyFor(); 2) it warns for Map.get(key) where elements are put in the map
+ * elsewhere, say not within the same function.
+ *
+ * <p>NullnessLite: No map key analysis; assume that, at every call to Map.get, the given key
+ * appears in the map. tests: 1) keyfor error still exists 2) the result of map.get() is always
+ * non-null.
+ */
+public class NullnessLiteMapKey1 {
+
+    // 1) keyfor error still exists
+    void test1() {
+        Map<@Nullable String, @Nullable String> m =
+                new HashMap<@Nullable String, @Nullable String>();
+        Map<String, @Nullable String> n = new HashMap<String, @Nullable String>();
+
+        @KeyFor("m") String km = new @KeyFor("m") String("km");
+        @KeyFor("n") String kn = new @KeyFor("n") String("kn");
+        @KeyFor({"m", "n"}) String kmn = new @KeyFor({"m", "n"}) String("kmn");
+
+        km = kmn;
+        // :: error: (assignment.type.incompatible)
+        km = kn;
+    }
+
+    // 2) the result of map.get() is always non-null.
+    void test2() {
+        Map<@Nullable String, @Nullable String> m =
+                new HashMap<@Nullable String, @Nullable String>();
+        Map<String, @Nullable String> n = new HashMap<String, @Nullable String>();
+
+        @KeyFor("m") String in = new @KeyFor("m") String("in");
+        String notin = "notin";
+        //        m.put(in, in);
+        //        n.put(in, in);
+
+        m.get(in).toString(); // OK - a key for map m
+        m.get(notin).toString(); // NullnessLite ON = no error
+    }
+
+    void showFalseWarningsAndErrors() {
+        Map<String, String> m = new HashMap<String, String>();
+
+        @KeyFor("m") String notin = new @KeyFor("m") String("in");
+        String in = "in";
+
+        foo(m, in);
+
+        m.get(notin).toString(); // error but no warning
+        m.get(in).toString(); // Ok but a warning
+    }
+
+    void showFalseWarnings() {
+        Map<String, String> m = new HashMap<String, String>();
+        String in = "in";
+        foo(m, in);
+
+        m.get(in).toString(); // Ok but a warning
+    }
+
+    void foo(Map<String, String> m, String in) {
+        m.put(in, in);
+        return;
+    }
+
+    void wierdKeyFor() {
+        Map<String, String> m = new HashMap<String, String>();
+
+        String in = "in";
+        foo(m, in);
+
+        m.get(in).toString(); // Ok but a warning
+    }
+}

--- a/checker/tests/nullness-liteoption-mapk/README
+++ b/checker/tests/nullness-liteoption-mapk/README
@@ -1,0 +1,9 @@
+s directory contains tests for the Nullness Checker, with the
+-ANullnessLite=mapk flag.
+
+To add a new file to the test suite, just add it to this directory.
+For more details, see
+  ../README
+
+To run the tests, do this:
+  (cd $CHECKERFRAMEWORK && ./gradlew NullnessLiteOptMapkTest)


### PR DESCRIPTION
Fix [Tests] Tests needed for -ANullnessLite=<FEATURE> #12 

Run tests together by 
```
cd $CHECKERFRAMEWORK && ./gradlew NullnessLiteOptInitTest \
&& cd $CHECKERFRAMEWORK && ./gradlew NullnessLiteOptMapkTest \
&& cd $CHECKERFRAMEWORK && ./gradlew NullnessLiteOptInvaTest \
&& cd $CHECKERFRAMEWORK && ./gradlew NullnessLiteOptBoxpTest
```
or `cd $CHECKERFRAMEWORK && ./gradlew allNullnessTests`

> -ANullnessLite= accept 4 values corresponding to four features:
> init = assume all values initialized
> mapk = Map.get() returns @nonnull (keys always exist in map)
> inva = no aliasing + all methods @sideeffectsfree (no invalidation of dataflow)
> boxp = boxedclass.valueOf() is @pure
> 
> By default, -ANullnessLite enables all features above.
> For example, if -ANullnessLite = Nullness Checker & init & mapk & inva & boxp,
> then -ANullnessLite=mapk = Nullness Checker & mapk.